### PR TITLE
Updated react peer depdendency to 18.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-signalr",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -21,7 +21,7 @@
       },
       "peerDependencies": {
         "@microsoft/signalr": "^6.0.1",
-        "react": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-signalr",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "React hooks for SignalR",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/pguilbert/react-use-signalr#readme",
   "peerDependencies": {
     "@microsoft/signalr": "^6.0.1",
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@microsoft/signalr": "^6.0.1",


### PR DESCRIPTION
Fix for #4 (Does not work with react 18).

Did not update the dev dependencies since "testing-library/react-hooks" is not yet compatible with react 18.